### PR TITLE
Use PaperLib for plugin teleports

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
         <dependency>
             <groupId>io.papermc</groupId>
             <artifactId>paperlib</artifactId>
-            <version>1.0.6</version>
+            <version>1.0.7</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,10 @@
             <id>2lstudios</id>
             <url>https://ci.2lstudios.dev/plugin/repository/everything/</url>
         </repository>
+        <repository>
+            <id>papermc</id>
+            <url>https://papermc.io/repo/repository/maven-public/</url>
+        </repository>
     </repositories>
 
     <!-- Dependencies imports -->
@@ -55,7 +59,7 @@
         <dependency>
             <groupId>dev._2lstudios</groupId>
             <artifactId>SwiftBoard</artifactId>
-            <version>0.0.2</version>
+            <version>0.0.4</version>
             <scope>provided</scope>
         </dependency>
 
@@ -65,12 +69,19 @@
             <version>2.10.10</version>
             <scope>provided</scope>
         </dependency>
+
+        <dependency>
+            <groupId>io.papermc</groupId>
+            <artifactId>paperlib</artifactId>
+            <version>1.0.6</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 
     <!-- Build settings -->
     <build>
         <!-- Name of your compiled artifact -->
-        <finalName>${artifactId}</finalName>
+        <finalName>${project.artifactId}</finalName>
         <!-- Directory of .java files -->
         <sourceDirectory>src/main/java</sourceDirectory>
         <!-- Clean old builds and install dependencies before compile -->

--- a/src/main/java/dev/_2lstudios/jelly/player/PluginPlayer.java
+++ b/src/main/java/dev/_2lstudios/jelly/player/PluginPlayer.java
@@ -5,7 +5,6 @@ import org.bukkit.Sound;
 import org.bukkit.entity.Player;
 
 import dev._2lstudios.jelly.utils.ServerUtils;
-import io.papermc.lib.PaperLib;
 
 public class PluginPlayer {
     private final Player player;
@@ -25,7 +24,7 @@ public class PluginPlayer {
     }
 
     public void teleport(final Location loc) {
-        PaperLib.teleportAsync(this.getBukkitPlayer(), loc);
+        this.getBukkitPlayer().teleport(loc);
     }
 
     public void sendTitle(final String title, final String subtitle, final int duration) {

--- a/src/main/java/dev/_2lstudios/jelly/player/PluginPlayer.java
+++ b/src/main/java/dev/_2lstudios/jelly/player/PluginPlayer.java
@@ -5,6 +5,7 @@ import org.bukkit.Sound;
 import org.bukkit.entity.Player;
 
 import dev._2lstudios.jelly.utils.ServerUtils;
+import io.papermc.lib.PaperLib;
 
 public class PluginPlayer {
     private final Player player;
@@ -24,7 +25,7 @@ public class PluginPlayer {
     }
 
     public void teleport(final Location loc) {
-        this.getBukkitPlayer().teleport(loc);
+        PaperLib.teleportAsync(this.getBukkitPlayer(), loc);
     }
 
     public void sendTitle(final String title, final String subtitle, final int duration) {

--- a/src/main/java/dev/_2lstudios/squidgame/arena/Arena.java
+++ b/src/main/java/dev/_2lstudios/squidgame/arena/Arena.java
@@ -16,6 +16,7 @@ import dev._2lstudios.squidgame.arena.games.G3BattleGame;
 import dev._2lstudios.squidgame.arena.games.G6GlassesGame;
 import dev._2lstudios.squidgame.arena.games.G7SquidGame;
 import dev._2lstudios.squidgame.player.SquidPlayer;
+import io.papermc.lib.PaperLib;
 
 public class Arena {
     private final List<SquidPlayer> players;
@@ -147,7 +148,7 @@ public class Arena {
         if (!this.players.contains(player) && !this.spectators.contains(player)) {
             this.joined = player.getBukkitPlayer().getName();
             this.players.add(player);
-            player.getBukkitPlayer().teleport(this.getSpawnPosition());
+            PaperLib.teleportAsync(player.getBukkitPlayer(), this.getSpawnPosition());
             player.getBukkitPlayer().setFoodLevel(20);
             player.getBukkitPlayer().setHealth(20);
             player.setArena(this);

--- a/src/main/java/dev/_2lstudios/squidgame/player/SquidPlayer.java
+++ b/src/main/java/dev/_2lstudios/squidgame/player/SquidPlayer.java
@@ -2,12 +2,14 @@ package dev._2lstudios.squidgame.player;
 
 import org.bukkit.ChatColor;
 import org.bukkit.GameMode;
+import org.bukkit.Location;
 import org.bukkit.entity.Player;
 
 import dev._2lstudios.jelly.player.PluginPlayer;
 import dev._2lstudios.squidgame.SquidGame;
 import dev._2lstudios.squidgame.arena.Arena;
 import dev._2lstudios.squidgame.hooks.PlaceholderAPIHook;
+import io.papermc.lib.PaperLib;
 
 public class SquidPlayer extends PluginPlayer {
 
@@ -60,6 +62,11 @@ public class SquidPlayer extends PluginPlayer {
 
     public void teleportToLobby() {
         this.teleport(this.plugin.getMainConfig().getLocation("lobby"));
+    }
+
+    @Override
+    public void teleport(final Location loc){
+        PaperLib.teleportAsync(this.getBukkitPlayer(), loc);
     }
 
     public String getI18n(final String key) {

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -5,9 +5,9 @@ main: ${mainClass}
 version: ${version}
 api-version: 1.13
 api: 1.13
-softdepends: ["PlaceholderAPI", "SwiftBoard"]
-softdepend:
+depend:
   - "PlaceholderAPI"
+softdepend:
   - "SwiftBoard"
 url: ${url}
 commands:


### PR DESCRIPTION
In case the plugin is executed in Paper 1.9+ and especially in Paper 1.15.2+ it will use its asynchronous teleport.
Otherwise, it will use the classic and heavy Bukkit/Spigot teleport.

In addition...
- Update SwiftBord dependency
- Change deprecated `${artifactId}` for `${project.artifactId}` in pom.xml
- PlaceholderAPI is required for the correct functioning of the plugin, so it is now a required dependency.